### PR TITLE
fix: harden background URL handling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ land before broader product and release-process work.
    Load saved settings before handling tab updates or toolbar clicks so browser
    service worker restarts do not reset the extension to default in memory.
 
-- [ ] Harden background URL handling.
+- [x] Harden background URL handling.
    Guard against missing or non-HTTP tab URLs before constructing `URL`
    instances, preventing runtime errors on browser pages or incomplete tab
    updates.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Web Only (Classic) Google Search",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "This extension automatically redirects your Google searches to the classic web only version of Google Search.",
   "author": "Pratyush Vashisht",
   "background": {

--- a/service_worker.js
+++ b/service_worker.js
@@ -58,6 +58,19 @@ let restoreExtensionDetails = async () => {
 let classicWebSearchSettingsReady = restoreExtensionDetails();
 
 let googleSearchHostnamePattern = /^(www\.)?google\.[a-z]{2,3}(\.[a-z]{2})?$/;
+let httpUrlPattern = /^https?:\/\//i;
+
+let getHttpTabUrl = tab => {
+  if (!tab || typeof tab.url !== 'string' || !httpUrlPattern.test(tab.url)) {
+    return null;
+  }
+
+  try {
+    return new URL(tab.url);
+  } catch (error) {
+    return null;
+  }
+};
 
 let isGoogleSearchPage = url => (
   googleSearchHostnamePattern.test(url.hostname) && url.pathname === '/search'
@@ -107,35 +120,39 @@ chrome.runtime.onInstalled.addListener(async installInfo => {
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   await classicWebSearchSettingsReady;
-  if (changeInfo.status === 'complete') {
-    const url = new URL(tab.url);
-    if (isGoogleSearchPage(url)) {
-      const query = url.searchParams.get('q');
-      const udm = url.searchParams.get('udm');
-      const alreadyClassicWebSearch = udm === '14';
-      const explicitSearchModeSelected = hasExplicitSearchMode(url);
-      // Only rewrite plain Google search pages. Existing udm/tbm modes represent
-      // the user's selected search type, such as Web, Images, News, or Shopping.
-      if (
-          query
-          && query !== classicWebSearchSettings.lastChangedSearch
-          && classicWebSearchSettings.isWebSearchEnabled
-          && !alreadyClassicWebSearch
-          && !explicitSearchModeSelected
-      ) {
-        url.searchParams.set('udm', '14');
-        chrome.tabs.update(tabId, { url: url.toString() }, () => {
-          if (chrome.runtime.lastError) return;
+  if (changeInfo.status !== 'complete') {
+    return;
+  }
 
-          saveAndApplyExtensionDetails({
-            lastChangedSearch: query,
-            num_changes: classicWebSearchSettings.num_changes + 1,
-          }).catch(logExtensionDetailsSaveFailure);
-        });
-      } else if (query && query !== classicWebSearchSettings.lastChangedSearch) {
-        saveAndApplyExtensionDetails({ lastChangedSearch: query })
-          .catch(logExtensionDetailsSaveFailure);
-      }
-    }
+  const url = getHttpTabUrl(tab);
+  if (!url || !isGoogleSearchPage(url)) {
+    return;
+  }
+
+  const query = url.searchParams.get('q');
+  const udm = url.searchParams.get('udm');
+  const alreadyClassicWebSearch = udm === '14';
+  const explicitSearchModeSelected = hasExplicitSearchMode(url);
+  // Only rewrite plain Google search pages. Existing udm/tbm modes represent
+  // the user's selected search type, such as Web, Images, News, or Shopping.
+  if (
+      query
+      && query !== classicWebSearchSettings.lastChangedSearch
+      && classicWebSearchSettings.isWebSearchEnabled
+      && !alreadyClassicWebSearch
+      && !explicitSearchModeSelected
+  ) {
+    url.searchParams.set('udm', '14');
+    chrome.tabs.update(tabId, { url: url.toString() }, () => {
+      if (chrome.runtime.lastError) return;
+
+      saveAndApplyExtensionDetails({
+        lastChangedSearch: query,
+        num_changes: classicWebSearchSettings.num_changes + 1,
+      }).catch(logExtensionDetailsSaveFailure);
+    });
+  } else if (query && query !== classicWebSearchSettings.lastChangedSearch) {
+    saveAndApplyExtensionDetails({ lastChangedSearch: query })
+      .catch(logExtensionDetailsSaveFailure);
   }
 });


### PR DESCRIPTION
## Summary

- Guard background tab URL parsing so missing, non-HTTP, and malformed tab URLs are ignored before constructing `URL` instances.
- Keep Google search redirect behavior unchanged for valid HTTP/HTTPS search pages.
- Bump the extension version from `1.3.2` to `1.3.3` and mark the roadmap item complete.

## Impact

Prevents runtime errors from browser pages, incomplete tab updates, or malformed tab URL values while preserving existing redirect protections.

## Validation

- `node --check service_worker.js`
- `git diff --check`