### PR TITLE
ci: use AMO Firefox add-on ID

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 VERSION=$(node -p "require('./manifest.json').version")
 DIST="dist"
-FIREFOX_GECKO_ID="{54c8aa56-f618-456d-996a-0260c64ffdcc}"
+FIREFOX_GECKO_ID="{245d8218-66d9-4631-86b2-7aa4c39c009b}"
 FIREFOX_MIN_VERSION="121.0"
 
 SOURCES=(


### PR DESCRIPTION
## Summary

- Replace the generated Firefox Gecko ID with the existing AMO add-on ID `{245d8218-66d9-4631-86b2-7aa4c39c009b}`.
- Keep the extension version at `1.4.0`; this corrects release packaging metadata from the existing release automation.

## Impact

The Firefox build output now matches the add-on ID AMO expects during upload.

## Validation

- `bash -n build.sh`
- `git diff --check`
- `./build.sh`
- Inspected `dist/classic-web-search-firefox-v1.4.0.zip` manifest and confirmed `browser_specific_settings.gecko.id` is `{245d8218-66d9-4631-86b2-7aa4c39c009b}`

## Follow-up

After this merges, rerun the Release workflow with `force=true` to regenerate and replace the existing `v1.4.0` release artifacts, or cut a new version if you prefer a fresh release tag.