### PR TITLE
chore: rename extension to Classic Web Search for Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Classic Web Search for Google Chrome Extension
 
-[![Version](https://img.shields.io/badge/Version-1.4.1-blue.svg)]()
+[![Version](https://img.shields.io/github/v/release/prvashisht/classic-web-search?sort=semver&label=Version)](https://github.com/prvashisht/classic-web-search/releases/latest)
 
 This Chrome extension automatically redirects your Google searches to the classic web-only results view.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Web Only (Classic) Google Search Chrome Extension
+# Classic Web Search for Google Chrome Extension
 
-[![Version](https://img.shields.io/badge/Version-1.3-blue.svg)]()
+[![Version](https://img.shields.io/badge/Version-1.4.1-blue.svg)]()
 
-This Chrome extension automatically redirects your Google searches to the classic web-only version of Google Search.
+This Chrome extension automatically redirects your Google searches to the classic web-only results view.
 
 ## Features
 
-- **Web Only Google Search:** Automatically redirects your Google searches to the classic web-only version.
+- **Classic Web Search for Google:** Automatically redirects your Google searches to the classic web-only results view.
 - **Dynamic Search:** The extension only works when the search query changes, allowing the user to switch to any other search type within the same query.
 - **Toggle Feature:** Easily enable or disable the extension with a single click from the extension icon.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-This document tracks planned improvements for Web Only (Classic) Google Search.
+This document tracks planned improvements for Classic Web Search for Google.
 It is ordered by suggested implementation priority so small, high-impact changes
 land before broader product and release-process work.
 

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ build() {
   echo "$outfile"
 }
 
-echo "Building Web Only (Classic) Google Search v$VERSION..."
+echo "Building Classic Web Search for Google v$VERSION..."
 
 build "chrome" "
   delete m.browser_specific_settings;

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Web Only (Classic) Google Search",
-  "version": "1.4.0",
-  "description": "This extension automatically redirects your Google searches to the classic web only version of Google Search.",
+  "name": "Classic Web Search for Google",
+  "short_name": "Classic Web",
+  "version": "1.4.1",
+  "description": "Automatically redirects your Google searches to the classic web-only results view.",
   "author": "Pratyush Vashisht",
   "background": {
     "service_worker": "service_worker.js",
@@ -24,7 +25,7 @@
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     },
-    "default_title": "Enable / Disable Web Only Google Search"
+    "default_title": "Enable / Disable Classic Web Search for Google"
   },
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary

- Rename the extension to `Classic Web Search for Google` for better extension-list ordering and search discoverability.
- Add `short_name: Classic Web` for compact browser UI surfaces.
- Bump the extension version to `1.4.1` and update visible docs/build output naming.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('manifest.json', 'utf8')); console.log('manifest ok')"`
- `./build.sh`
- Verified both generated Chrome and Firefox package manifests contain `Classic Web Search for Google`, `Classic Web`, and `1.4.1`.
- `git diff --check`