### PR TITLE
docs: fix README version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Classic Web Search for Google Chrome Extension
 
-[![Version](https://img.shields.io/github/v/release/prvashisht/classic-web-search?sort=semver&label=Version)](https://github.com/prvashisht/classic-web-search/releases/latest)
+[![Version](https://img.shields.io/github/manifest-json/v/prvashisht/classic-web-search?label=Version)](https://github.com/prvashisht/classic-web-search/blob/main/manifest.json)
 
 This Chrome extension automatically redirects your Google searches to the classic web-only results view.
 


### PR DESCRIPTION
## Summary

- Replace the GitHub Release version badge with Shields' GitHub manifest-version badge.
- Link the badge to `manifest.json`, which is the extension version source of truth.

## Why

The release badge can render `version invalid` when GitHub Release metadata is missing or not yet available. Reading the root `manifest.json` avoids manual README bumps and does not depend on release creation timing.

## Validation

- `git diff --check`