### PR TITLE
feat: add extension controls and store deploy skip

### DIFF
--- a/.github/store-deploy-skip-versions.txt
+++ b/.github/store-deploy-skip-versions.txt
@@ -1,0 +1,7 @@
+# Versions listed here skip the automatic Chrome Web Store and Firefox Add-ons
+# deploy that normally runs after the Release workflow succeeds.
+#
+# Manual Store Deploy workflow dispatch is still allowed for these versions.
+# Accepts either 1.5.0 or v1.5.0.
+
+1.5.0

--- a/.github/workflows/store-deploy.yml
+++ b/.github/workflows/store-deploy.yml
@@ -27,7 +27,13 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       version: ${{ steps.resolve.outputs.version }}
+      skip_store_deploy: ${{ steps.skip.outputs.skip_store_deploy }}
+      skip_reason: ${{ steps.skip.outputs.skip_reason }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+
       - name: Resolve release version
         id: resolve
         env:
@@ -47,11 +53,47 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check automatic store deploy skip list
+        id: skip
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          SKIP_STORE_DEPLOY=false
+          SKIP_REASON=""
+
+          if [ "${{ github.event_name }}" = "workflow_run" ] && [ -f ".github/store-deploy-skip-versions.txt" ]; then
+            if awk -v version="${VERSION#v}" '
+              {
+                sub(/#.*/, "", $0)
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+                if ($0 == version || $0 == "v" version) {
+                  found = 1
+                }
+              }
+              END { exit found ? 0 : 1 }
+            ' .github/store-deploy-skip-versions.txt; then
+              SKIP_STORE_DEPLOY=true
+              SKIP_REASON="Automatic store deploy skipped because v${VERSION#v} is listed in .github/store-deploy-skip-versions.txt"
+            fi
+          fi
+
+          echo "skip_store_deploy=$SKIP_STORE_DEPLOY" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
+
+  skipped:
+    needs: resolve
+    runs-on: ubuntu-latest
+    if: needs.resolve.outputs.skip_store_deploy == 'true'
+    steps:
+      - name: Report skipped store deployment
+        run: echo "::notice::${{ needs.resolve.outputs.skip_reason }}"
+
   chrome:
     needs: resolve
     runs-on: ubuntu-latest
     if: |
       needs.resolve.outputs.version != '' &&
+      needs.resolve.outputs.skip_store_deploy != 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.stores == 'all' || inputs.stores == 'chrome')
     env:
       CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
@@ -101,6 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       needs.resolve.outputs.version != '' &&
+      needs.resolve.outputs.skip_store_deploy != 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.stores == 'all' || inputs.stores == 'firefox')
     env:
       FIREFOX_API_KEY: ${{ secrets.FIREFOX_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ git clone
 - **Chrome / Edge**: `chrome://extensions/shortcuts`
 - **Firefox**: `about:addons` -> Extensions -> Classic Web Search for Google -> Manage
 
+## Release controls
+
+Merging a manifest version change to `main` creates a GitHub release and, by default, deploys that release to the browser stores.
+
+To create a release without automatic store deployment, add the version to `.github/store-deploy-skip-versions.txt` before merging. Manual deployment remains available from the **Store Deploy** workflow for skipped versions.
+
 ## Files
 
 - **`manifest.json`**: Contains metadata about the extension, including permissions, icons, and scripts.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# Classic Web Search for Google Chrome Extension
+# Classic Web Search for Google
 
 [![Version](https://img.shields.io/github/manifest-json/v/prvashisht/classic-web-search?label=Version)](https://github.com/prvashisht/classic-web-search/blob/main/manifest.json)
 
-This Chrome extension automatically redirects your Google searches to the classic web-only results view.
+This browser extension automatically redirects your Google searches to the classic web-only results view.
 
 ## Features
 
 - **Classic Web Search for Google:** Automatically redirects your Google searches to the classic web-only results view.
 - **Dynamic Search:** The extension only works when the search query changes, allowing the user to switch to any other search type within the same query.
-- **Toggle Feature:** Easily enable or disable the extension with a single click from the extension icon.
+- **Toolbar Toggle:** Easily enable or disable the extension with a single click from the extension icon.
+- **Keyboard Shortcut:** Toggle the extension with **Alt+Shift+W**. The shortcut can be remapped in your browser's extension shortcut settings.
+- **Context Menu Controls:** Right-click the extension icon to toggle the extension, manage the extension, manage shortcuts, rate/review the extension, or report a bug/request support.
 
 ## Installation
 
@@ -25,10 +27,21 @@ git clone
 
 4. Click on `Load unpacked` and select the cloned repository folder.
 
+## Usage
+
+- Click the extension icon to turn Classic Web Search on or off.
+- Press **Alt+Shift+W** to toggle the extension without opening the toolbar.
+- Right-click the extension icon to access the toggle, extension management page, keyboard shortcut settings, review link, and support link.
+
+### Keyboard shortcut remap
+
+- **Chrome / Edge**: `chrome://extensions/shortcuts`
+- **Firefox**: `about:addons` -> Extensions -> Classic Web Search for Google -> Manage
+
 ## Files
 
 - **`manifest.json`**: Contains metadata about the extension, including permissions, icons, and scripts.
-- **`service_worker.js`**: Manages the extension behavior in the background, including badge text, color, and Google Search URL redirects.
+- **`service_worker.js`**: Manages the extension behavior in the background, including badge text, color, toggle controls, context menu actions, and Google Search URL redirects.
 
 ## How to Contribute
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,10 +63,10 @@ land before broader product and release-process work.
 
 ## Priority 4: User Controls
 
-- [ ] Add a keyboard shortcut.
+- [x] Add a keyboard shortcut.
    Let users toggle the extension without opening the toolbar menu.
 
-- [ ] Add context menu actions.
+- [x] Add context menu actions.
    Add actions for enable/disable, settings, keyboard shortcuts, rating, and
    bug reporting.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Classic Web Search for Google",
   "short_name": "Classic Web",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Automatically redirects your Google searches to the classic web-only results view.",
   "author": "Pratyush Vashisht",
   "background": {
@@ -27,7 +27,17 @@
     },
     "default_title": "Enable / Disable Classic Web Search for Google"
   },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+W",
+        "mac": "Alt+Shift+W"
+      },
+      "description": "Toggle Classic Web Search for Google on/off"
+    }
+  },
   "permissions": [
+    "contextMenus",
     "storage",
     "tabs"
   ]

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,5 +1,13 @@
 import { webext } from './webext.js';
 
+const CONTEXT_MENU_TOGGLE_ID = "toggle-classic-web-search";
+const CONTEXT_MENU_MANAGE_ID = "manage-extension";
+const CONTEXT_MENU_SHORTCUTS_ID = "manage-keyboard-shortcuts";
+const CONTEXT_MENU_RATE_ID = "rate-classic-web-search";
+const CONTEXT_MENU_SUPPORT_ID = "report-bug-or-support";
+const RATE_REVIEW_URL = "https://vashis.ht/rd/classicwebsearch?from=classicwebsearch-extension-context_menu";
+const SUPPORT_URL = "https://github.com/prvashisht/classic-web-search/issues/new";
+
 let classicWebSearchSettings = {
   isWebSearchEnabled: false,
   lastChangedSearch: "",
@@ -27,6 +35,23 @@ let setExtensionUninstallURL = (settings) => {
   }
 };
 
+let updateContextMenuState = () => {
+  if (!webext.contextMenus?.update) {
+    return;
+  }
+
+  try {
+    const result = webext.contextMenus.update(CONTEXT_MENU_TOGGLE_ID, {
+      checked: classicWebSearchSettings.isWebSearchEnabled,
+    });
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  } catch (error) {
+    // The menu may not exist yet during startup or immediately after install.
+  }
+};
+
 let applyExtensionDetails = details => {
   classicWebSearchSettings = { ...classicWebSearchSettings, ...details };
 
@@ -38,6 +63,8 @@ let applyExtensionDetails = details => {
   webext.action.setBadgeBackgroundColor({
     color: classicWebSearchSettings.isWebSearchEnabled ? "#00FF00" : "#F00000",
   });
+
+  updateContextMenuState();
 };
 
 let saveAndApplyExtensionDetails = async details => {
@@ -68,6 +95,69 @@ let restoreExtensionDetails = async () => {
 
 let classicWebSearchSettingsReady = restoreExtensionDetails();
 
+let createContextMenu = details => {
+  try {
+    webext.contextMenus.create(details);
+  } catch (error) {
+    console.warn("Failed to create context menu item", details.id, error);
+  }
+};
+
+let buildContextMenus = async () => {
+  if (!webext.contextMenus?.removeAll) {
+    return;
+  }
+
+  try {
+    const result = webext.contextMenus.removeAll();
+    if (result && typeof result.then === 'function') {
+      await result;
+    }
+  } catch (error) {
+    console.warn("Failed to reset context menu", error);
+  }
+
+  createContextMenu({
+    id: CONTEXT_MENU_TOGGLE_ID,
+    type: "checkbox",
+    title: "Enable Classic Web Search",
+    contexts: ["action"],
+    checked: classicWebSearchSettings.isWebSearchEnabled,
+  });
+  createContextMenu({
+    id: CONTEXT_MENU_MANAGE_ID,
+    title: "Manage extension",
+    contexts: ["action"],
+  });
+  createContextMenu({
+    id: CONTEXT_MENU_SHORTCUTS_ID,
+    title: "Manage keyboard shortcuts",
+    contexts: ["action"],
+  });
+  createContextMenu({
+    id: CONTEXT_MENU_RATE_ID,
+    title: "Rate / review Classic Web Search",
+    contexts: ["action"],
+  });
+  createContextMenu({
+    id: CONTEXT_MENU_SUPPORT_ID,
+    title: "Report a bug / request support",
+    contexts: ["action"],
+  });
+};
+
+let contextMenusReady = Promise.resolve();
+let scheduleBuildContextMenus = () => {
+  contextMenusReady = contextMenusReady.then(buildContextMenus, buildContextMenus);
+  return contextMenusReady;
+};
+
+classicWebSearchSettingsReady
+  .then(scheduleBuildContextMenus)
+  .catch(error => {
+    console.warn("Failed to initialize context menus", error);
+  });
+
 let googleSearchHostnamePattern = /^(www\.)?google\.[a-z]{2,3}(\.[a-z]{2})?$/;
 let httpUrlPattern = /^https?:\/\//i;
 
@@ -91,11 +181,46 @@ let hasExplicitSearchMode = url => (
   url.searchParams.has('udm') || url.searchParams.has('tbm')
 );
 
-webext.action.onClicked.addListener(async () => {
+let setClassicWebSearchEnabled = async isEnabled => {
   await classicWebSearchSettingsReady;
   await saveAndApplyExtensionDetails({
-    isWebSearchEnabled: !classicWebSearchSettings.isWebSearchEnabled,
+    isWebSearchEnabled: isEnabled,
   });
+};
+
+let toggleClassicWebSearch = async () => {
+  await classicWebSearchSettingsReady;
+  await setClassicWebSearchEnabled(!classicWebSearchSettings.isWebSearchEnabled);
+};
+
+webext.action.onClicked.addListener(async () => {
+  await toggleClassicWebSearch();
+});
+
+webext.contextMenus.onClicked.addListener(async info => {
+  await classicWebSearchSettingsReady;
+
+  switch (info.menuItemId) {
+    case CONTEXT_MENU_TOGGLE_ID:
+      await setClassicWebSearchEnabled(
+        typeof info.checked === 'boolean'
+          ? info.checked
+          : !classicWebSearchSettings.isWebSearchEnabled
+      );
+      break;
+    case CONTEXT_MENU_MANAGE_ID:
+      await webext.openExtensionPage();
+      break;
+    case CONTEXT_MENU_SHORTCUTS_ID:
+      await webext.openShortcutsPage();
+      break;
+    case CONTEXT_MENU_RATE_ID:
+      await webext.tabs.create({ url: RATE_REVIEW_URL });
+      break;
+    case CONTEXT_MENU_SUPPORT_ID:
+      await webext.tabs.create({ url: SUPPORT_URL });
+      break;
+  }
 });
 
 webext.runtime.onInstalled.addListener(async installInfo => {
@@ -120,6 +245,7 @@ webext.runtime.onInstalled.addListener(async installInfo => {
   const data = await webext.storage.sync.get("classicWebSearchSettings");
   if (!data.classicWebSearchSettings) {
     await saveAndApplyExtensionDetails(debugData);
+    await scheduleBuildContextMenus();
     return;
   }
   await saveAndApplyExtensionDetails({
@@ -127,6 +253,7 @@ webext.runtime.onInstalled.addListener(async installInfo => {
     ...debugData,
     num_changes: data.classicWebSearchSettings.num_changes || 0,
   });
+  await scheduleBuildContextMenus();
 });
 
 webext.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {

--- a/webext.js
+++ b/webext.js
@@ -10,7 +10,26 @@ export const isChromium = !isFirefoxRuntime;
 
 export const webext = {
   action: extensionApi.action,
+  contextMenus: extensionApi.contextMenus,
   runtime: extensionApi.runtime,
   storage: extensionApi.storage,
   tabs: extensionApi.tabs,
+  openExtensionPage: async () => {
+    if (isFirefoxRuntime) {
+      await extensionApi.tabs.create({ url: 'about:addons' });
+      return;
+    }
+
+    await extensionApi.tabs.create({
+      url: `chrome://extensions/?id=${extensionApi.runtime.id}`,
+    });
+  },
+  openShortcutsPage: async () => {
+    if (isFirefoxRuntime) {
+      await extensionApi.tabs.create({ url: 'about:addons' });
+      return;
+    }
+
+    await extensionApi.tabs.create({ url: 'chrome://extensions/shortcuts' });
+  },
 };

--- a/webext.js
+++ b/webext.js
@@ -1,6 +1,6 @@
 const isFirefoxRuntime = (
   typeof browser !== "undefined"
-  && typeof browser.runtime?.getManifest === "function"
+  && /Firefox\//.test(navigator.userAgent)
 );
 
 const extensionApi = isFirefoxRuntime ? browser : chrome;


### PR DESCRIPTION
## Summary

- Add an `Alt+Shift+W` browser action shortcut so the existing toolbar toggle path can be triggered from the keyboard.
- Add extension action context menu controls for enabling/disabling, managing the extension, managing keyboard shortcuts, rating/reviewing, and reporting bugs/requesting support.
- Keep enable/disable state centralized through the existing persisted settings and badge update flow.
- Fix the browser adapter so Chromium-family browsers such as Brave do not get classified as Firefox just because they expose `browser.*`.
- Bump the extension version to `1.5.0`, document the new controls, and mark the keyboard shortcut/context menu roadmap items complete.
- Add `.github/store-deploy-skip-versions.txt` so specific versions can skip automatic Chrome Web Store and Firefox Add-ons deployment after a release. `1.5.0` is listed so this PR creates the GitHub release but does not auto-deploy to stores; manual Store Deploy workflow dispatch remains available.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('manifest.json', 'utf8')); console.log('manifest ok')"`
- `node --check service_worker.js`
- `node --check webext.js`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/store-deploy.yml'); YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml ok'"`
- Local skip-list shell checks: `1.5.0` matches `.github/store-deploy-skip-versions.txt`; `1.5.1` does not.
- `git diff --check`
- `./build.sh`
- `unzip -t dist/classic-web-search-chrome-v1.5.0.zip`
- `unzip -t dist/classic-web-search-firefox-v1.5.0.zip`
- Inspected generated Chrome and Firefox `manifest.json` outputs from the built zips for `version`, `commands`, `contextMenus`, and Firefox background/gecko transform fields.