### PR TITLE
feat: add options dashboard

### DIFF
--- a/.github/release-controls.conf
+++ b/.github/release-controls.conf
@@ -7,5 +7,5 @@
 # skip_deploy=true allows GitHub releases but prevents Chrome Web Store and
 # Firefox Add-ons deployment. skip_release=true also skips deployment.
 
-skip_release=false
+skip_release=true
 skip_deploy=false

--- a/.github/release-controls.conf
+++ b/.github/release-controls.conf
@@ -1,0 +1,11 @@
+# Release automation controls.
+#
+# skip_release=true prevents the GitHub Release workflow from creating or
+# updating a release for the manifest version. Changing it back to false runs
+# the workflow again and creates the release if the vX.Y.Z tag does not exist.
+#
+# skip_deploy=true allows GitHub releases but prevents Chrome Web Store and
+# Firefox Add-ons deployment. skip_release=true also skips deployment.
+
+skip_release=false
+skip_deploy=false

--- a/.github/scripts/read-release-controls.sh
+++ b/.github/scripts/read-release-controls.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONTROL_FILE="${1:-.github/release-controls.conf}"
+SKIP_RELEASE=false
+SKIP_DEPLOY=false
+
+normalize_bool() {
+  local key="$1"
+  local value="$2"
+
+  case "$value" in
+    true|yes|1)
+      echo "true"
+      ;;
+    false|no|0|"")
+      echo "false"
+      ;;
+    *)
+      echo "::error file=$CONTROL_FILE::Invalid $key value '$value'. Use true or false."
+      exit 1
+      ;;
+  esac
+}
+
+write_output() {
+  local key="$1"
+  local value="$2"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "$key=$value" >> "$GITHUB_OUTPUT"
+  else
+    echo "$key=$value"
+  fi
+}
+
+if [ -r "$CONTROL_FILE" ]; then
+  while IFS='=' read -r raw_key raw_value || [ -n "${raw_key:-}" ]; do
+    key="$(printf '%s' "$raw_key" | sed 's/#.*//; s/^[[:space:]]*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')"
+    value="$(printf '%s' "${raw_value:-}" | sed 's/#.*//; s/^[[:space:]]*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')"
+
+    if [ -z "$key" ]; then
+      continue
+    fi
+
+    case "$key" in
+      skip_release)
+        SKIP_RELEASE="$(normalize_bool "$key" "$value")"
+        ;;
+      skip_deploy)
+        SKIP_DEPLOY="$(normalize_bool "$key" "$value")"
+        ;;
+      *)
+        echo "::warning file=$CONTROL_FILE::Ignoring unknown release control '$key'"
+        ;;
+    esac
+  done < "$CONTROL_FILE"
+fi
+
+if [ "$SKIP_RELEASE" = "true" ]; then
+  SKIP_DEPLOY_EFFECTIVE=true
+else
+  SKIP_DEPLOY_EFFECTIVE="$SKIP_DEPLOY"
+fi
+
+write_output "skip_release" "$SKIP_RELEASE"
+write_output "skip_deploy" "$SKIP_DEPLOY"
+write_output "skip_deploy_effective" "$SKIP_DEPLOY_EFFECTIVE"

--- a/.github/store-deploy-skip-versions.txt
+++ b/.github/store-deploy-skip-versions.txt
@@ -1,7 +1,0 @@
-# Versions listed here skip the automatic Chrome Web Store and Firefox Add-ons
-# deploy that normally runs after the Release workflow succeeds.
-#
-# Manual Store Deploy workflow dispatch is still allowed for these versions.
-# Accepts either 1.5.0 or v1.5.0.
-
-1.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release
 on:
   push:
     branches: [main]
-    paths: [manifest.json]
+    paths:
+      - manifest.json
+      - .github/release-controls.conf
+      - .github/scripts/read-release-controls.sh
   workflow_dispatch:
     inputs:
       force:
@@ -29,16 +32,9 @@ jobs:
           VERSION="$(node -p "require('./manifest.json').version")"
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Read previous version from manifest
-        id: previous
-        if: github.event_name == 'push'
-        run: |
-          if git show "${{ github.event.before }}:manifest.json" >/tmp/previous-manifest.json 2>/dev/null; then
-            PREVIOUS_VERSION="$(node -p "require('/tmp/previous-manifest.json').version")"
-          else
-            PREVIOUS_VERSION=""
-          fi
-          echo "value=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Read release controls
+        id: controls
+        run: bash .github/scripts/read-release-controls.sh
 
       - name: Check if tag already exists
         id: tag
@@ -49,32 +45,45 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Decide whether to release
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FORCE: ${{ inputs.force || false }}
+          SKIP_RELEASE: ${{ steps.controls.outputs.skip_release }}
+          TAG_EXISTS: ${{ steps.tag.outputs.exists }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          SHOULD_RELEASE=false
+          REASON=""
+
+          if [ "$SKIP_RELEASE" = "true" ]; then
+            REASON="Release skipped because skip_release=true in .github/release-controls.conf"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$FORCE" = "true" ]; then
+            SHOULD_RELEASE=true
+            REASON="Release will be created or updated for v$VERSION because force=true"
+          elif [ "$TAG_EXISTS" = "true" ]; then
+            REASON="Release skipped because tag v$VERSION already exists"
+          else
+            SHOULD_RELEASE=true
+            REASON="Release will be created for v$VERSION"
+          fi
+
+          echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+
+      - name: Report release skip
+        if: steps.plan.outputs.should_release != 'true'
+        run: echo "::notice::${{ steps.plan.outputs.reason }}"
+
       - name: Build extension zips
-        if: >-
-          (
-            github.event_name == 'push' &&
-            steps.version.outputs.value != steps.previous.outputs.value &&
-            steps.tag.outputs.exists == 'false'
-          ) ||
-          (
-            github.event_name == 'workflow_dispatch' &&
-            (steps.tag.outputs.exists == 'false' || inputs.force)
-          )
+        if: steps.plan.outputs.should_release == 'true'
         run: |
           chmod +x build.sh
           ./build.sh
 
       - name: Create GitHub release
-        if: >-
-          (
-            github.event_name == 'push' &&
-            steps.version.outputs.value != steps.previous.outputs.value &&
-            steps.tag.outputs.exists == 'false'
-          ) ||
-          (
-            github.event_name == 'workflow_dispatch' &&
-            (steps.tag.outputs.exists == 'false' || inputs.force)
-          )
+        if: steps.plan.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.value }}

--- a/.github/workflows/store-deploy.yml
+++ b/.github/workflows/store-deploy.yml
@@ -34,14 +34,42 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
+      - name: Read release controls
+        id: controls
+        run: bash .github/scripts/read-release-controls.sh
+
+      - name: Check store deploy controls
+        id: skip
+        env:
+          SKIP_RELEASE: ${{ steps.controls.outputs.skip_release }}
+          SKIP_DEPLOY_EFFECTIVE: ${{ steps.controls.outputs.skip_deploy_effective }}
+        run: |
+          SKIP_STORE_DEPLOY=false
+          SKIP_REASON=""
+
+          if [ "$SKIP_RELEASE" = "true" ]; then
+            SKIP_STORE_DEPLOY=true
+            SKIP_REASON="Store deploy skipped because skip_release=true in .github/release-controls.conf"
+          elif [ "$SKIP_DEPLOY_EFFECTIVE" = "true" ]; then
+            SKIP_STORE_DEPLOY=true
+            SKIP_REASON="Store deploy skipped because skip_deploy=true in .github/release-controls.conf"
+          fi
+
+          echo "skip_store_deploy=$SKIP_STORE_DEPLOY" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
+
       - name: Resolve release version
         id: resolve
+        if: steps.skip.outputs.skip_store_deploy != 'true'
         env:
+          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "workflow_run" ]; then
+            VERSION="$(node -p "require('./manifest.json').version")"
           else
             VERSION="$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName -q '.[0].tagName' | sed 's/^v//')"
           fi
@@ -52,33 +80,6 @@ jobs:
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Check automatic store deploy skip list
-        id: skip
-        env:
-          VERSION: ${{ steps.resolve.outputs.version }}
-        run: |
-          SKIP_STORE_DEPLOY=false
-          SKIP_REASON=""
-
-          if [ "${{ github.event_name }}" = "workflow_run" ] && [ -f ".github/store-deploy-skip-versions.txt" ]; then
-            if awk -v version="${VERSION#v}" '
-              {
-                sub(/#.*/, "", $0)
-                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-                if ($0 == version || $0 == "v" version) {
-                  found = 1
-                }
-              }
-              END { exit found ? 0 : 1 }
-            ' .github/store-deploy-skip-versions.txt; then
-              SKIP_STORE_DEPLOY=true
-              SKIP_REASON="Automatic store deploy skipped because v${VERSION#v} is listed in .github/store-deploy-skip-versions.txt"
-            fi
-          fi
-
-          echo "skip_store_deploy=$SKIP_STORE_DEPLOY" >> "$GITHUB_OUTPUT"
-          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
 
   skipped:
     needs: resolve

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This browser extension automatically redirects your Google searches to the class
 - **Dynamic Search:** The extension only works when the search query changes, allowing the user to switch to any other search type within the same query.
 - **Toolbar Toggle:** Easily enable or disable the extension with a single click from the extension icon.
 - **Keyboard Shortcut:** Toggle the extension with **Alt+Shift+W**. The shortcut can be remapped in your browser's extension shortcut settings.
-- **Context Menu Controls:** Right-click the extension icon to toggle the extension, manage the extension, manage shortcuts, rate/review the extension, or report a bug/request support.
+- **Context Menu Controls:** Right-click the extension icon to toggle the extension, open options, manage shortcuts, rate/review the extension, or report a bug/request support.
+- **Options Dashboard:** View the current state, redirect count, installed version, release notes, and support links.
 
 ## Installation
 
@@ -31,7 +32,7 @@ git clone
 
 - Click the extension icon to turn Classic Web Search on or off.
 - Press **Alt+Shift+W** to toggle the extension without opening the toolbar.
-- Right-click the extension icon to access the toggle, extension management page, keyboard shortcut settings, review link, and support link.
+- Right-click the extension icon to access the toggle, options page, keyboard shortcut settings, review link, and support link.
 
 ### Keyboard shortcut remap
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ git clone
 
 Merging a manifest version change to `main` creates a GitHub release and, by default, deploys that release to the browser stores.
 
-To create a release without automatic store deployment, add the version to `.github/store-deploy-skip-versions.txt` before merging. Manual deployment remains available from the **Store Deploy** workflow for skipped versions.
+Use `.github/release-controls.conf` to pause release automation:
+
+- `skip_release=true` skips GitHub release creation and store deployment. Set it back to `false` to run the release for the current manifest version if the tag does not already exist.
+- `skip_deploy=true` creates the GitHub release but skips Chrome Web Store and Firefox Add-ons deployment.
 
 ## Files
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,9 +74,9 @@ land before broader product and release-process work.
    Provide a small dashboard for current state, redirect count, version,
    release notes, and support links.
 
-- [ ] Track redirect count accurately.
+- ~~[ ] Track redirect count accurately.
    Count successful automatic redirects and expose the value in storage and the
-   options page.
+   options page.~~
 
 ## Priority 5: Repository Maintenance
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ land before broader product and release-process work.
    Add actions for enable/disable, settings, keyboard shortcuts, rating, and
    bug reporting.
 
-- [ ] Add an options page.
+- [x] Add an options page.
    Provide a small dashboard for current state, redirect count, version,
    release notes, and support links.
 

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,9 @@ FIREFOX_MIN_VERSION="121.0"
 
 SOURCES=(
   icons
+  options.css
+  options.html
+  options.js
   service_worker.js
   webext.js
 )

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,10 @@
     },
     "default_title": "Enable / Disable Classic Web Search for Google"
   },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "commands": {
     "_execute_action": {
       "suggested_key": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Classic Web Search for Google",
   "short_name": "Classic Web",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Automatically redirects your Google searches to the classic web-only results view.",
   "author": "Pratyush Vashisht",
   "background": {

--- a/options.css
+++ b/options.css
@@ -1,0 +1,290 @@
+:root {
+  color-scheme: light dark;
+  --page-bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-muted: #f0f3f7;
+  --text: #1d232f;
+  --muted: #637083;
+  --border: #d9dee8;
+  --brand: #1769e0;
+  --brand-strong: #0f55bb;
+  --enabled: #16833a;
+  --enabled-bg: #e7f5ec;
+  --disabled: #a63a28;
+  --disabled-bg: #fbe9e5;
+  --shadow: 0 18px 45px rgba(30, 43, 62, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #15181d;
+    --surface: #20242b;
+    --surface-muted: #2a3039;
+    --text: #f0f3f8;
+    --muted: #adb7c5;
+    --border: #3a424f;
+    --brand: #7ab0ff;
+    --brand-strong: #a9cbff;
+    --enabled: #77d897;
+    --enabled-bg: #183a25;
+    --disabled: #f09b8c;
+    --disabled-bg: #4a241f;
+    --shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(180deg, var(--surface-muted) 0, var(--page-bg) 300px);
+  font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+a {
+  font: inherit;
+}
+
+.options-shell {
+  width: min(980px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 40px 0;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: clamp(2rem, 7vw, 3.6rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 8px;
+  font-size: 1.25rem;
+  letter-spacing: 0;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+body.state-enabled .status-pill {
+  border-color: color-mix(in srgb, var(--enabled), transparent 55%);
+  background: var(--enabled-bg);
+  color: var(--enabled);
+}
+
+body.state-disabled .status-pill {
+  border-color: color-mix(in srgb, var(--disabled), transparent 55%);
+  background: var(--disabled-bg);
+  color: var(--disabled);
+}
+
+.status-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.state-summary {
+  max-width: 52ch;
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.primary-action,
+.text-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.primary-action {
+  min-width: 150px;
+  padding: 10px 18px;
+  border: 1px solid var(--brand-strong);
+  background: var(--brand);
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.primary-action:hover {
+  background: var(--brand-strong);
+}
+
+.primary-action:disabled {
+  cursor: wait;
+  border-color: var(--border);
+  background: var(--surface-muted);
+  color: var(--muted);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0 0 18px;
+}
+
+.metric-tile {
+  min-height: 128px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.metric-label {
+  display: block;
+  margin-bottom: 18px;
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.metric-value {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: clamp(1.7rem, 5vw, 2.6rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.metric-link,
+.text-action {
+  color: var(--brand);
+  font-size: 1.1rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.metric-link:hover,
+.link-band a:hover,
+.text-action:hover {
+  text-decoration: underline;
+}
+
+.text-action {
+  min-height: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.link-band {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.link-band a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.link-band a:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+@media (max-width: 760px) {
+  .options-shell {
+    width: min(100% - 20px, 680px);
+    padding: 24px 0;
+  }
+
+  .page-header,
+  .status-panel {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .status-pill {
+    width: fit-content;
+  }
+
+  .primary-action {
+    width: 100%;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 460px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .link-band {
+    flex-direction: column;
+  }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Classic Web Search Options</title>
+  <link rel="stylesheet" href="options.css">
+</head>
+<body>
+  <main class="options-shell">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">Classic Web Search for Google</p>
+        <h1>Options</h1>
+      </div>
+      <div class="status-pill" id="status-pill" aria-live="polite">
+        <span class="status-dot" aria-hidden="true"></span>
+        <span id="status-label">Loading</span>
+      </div>
+    </header>
+
+    <section class="status-panel" aria-labelledby="status-heading">
+      <div>
+        <h2 id="status-heading">Search Redirects</h2>
+        <p class="state-summary" id="state-summary">Loading current state</p>
+      </div>
+      <button class="primary-action" id="toggle-button" type="button" disabled>
+        Loading
+      </button>
+    </section>
+
+    <section class="dashboard-grid" aria-label="Dashboard">
+      <article class="metric-tile">
+        <span class="metric-label">Automatic redirects</span>
+        <strong class="metric-value" id="redirect-count">0</strong>
+      </article>
+      <article class="metric-tile">
+        <span class="metric-label">Version</span>
+        <strong class="metric-value" id="version-number">-</strong>
+      </article>
+      <article class="metric-tile">
+        <span class="metric-label">Release notes</span>
+        <a class="metric-link" id="release-notes-link" href="#" target="_blank" rel="noopener">Open</a>
+      </article>
+      <article class="metric-tile">
+        <span class="metric-label">Shortcuts</span>
+        <button class="text-action" id="shortcuts-button" type="button">Manage</button>
+      </article>
+    </section>
+
+    <section class="link-band" aria-label="Support">
+      <a href="https://github.com/prvashisht/classic-web-search/issues/new" target="_blank" rel="noopener">
+        Report a bug
+      </a>
+      <a href="https://vashis.ht/rd/classicwebsearch?from=classicwebsearch-extension-options" target="_blank" rel="noopener">
+        Rate or review
+      </a>
+      <a href="https://github.com/prvashisht/classic-web-search" target="_blank" rel="noopener">
+        GitHub repository
+      </a>
+    </section>
+  </main>
+
+  <script type="module" src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,97 @@
+import { webext } from './webext.js';
+
+const SETTINGS_KEY = 'classicWebSearchSettings';
+const DEFAULT_SETTINGS = {
+  isWebSearchEnabled: false,
+  num_changes: 0,
+};
+
+const statusLabel = document.querySelector('#status-label');
+const stateSummary = document.querySelector('#state-summary');
+const toggleButton = document.querySelector('#toggle-button');
+const redirectCount = document.querySelector('#redirect-count');
+const versionNumber = document.querySelector('#version-number');
+const releaseNotesLink = document.querySelector('#release-notes-link');
+const shortcutsButton = document.querySelector('#shortcuts-button');
+
+let currentSettings = { ...DEFAULT_SETTINGS };
+
+const formatCount = count => new Intl.NumberFormat().format(count || 0);
+
+const getStoredSettings = async () => {
+  const data = await webext.storage.sync.get(SETTINGS_KEY);
+  return {
+    ...DEFAULT_SETTINGS,
+    ...(data[SETTINGS_KEY] || {}),
+  };
+};
+
+const saveSettings = async settings => {
+  const nextSettings = {
+    ...currentSettings,
+    ...settings,
+  };
+  await webext.storage.sync.set({ [SETTINGS_KEY]: nextSettings });
+  currentSettings = nextSettings;
+  render(currentSettings);
+};
+
+const render = settings => {
+  const isEnabled = Boolean(settings.isWebSearchEnabled);
+  document.body.classList.toggle('state-enabled', isEnabled);
+  document.body.classList.toggle('state-disabled', !isEnabled);
+
+  statusLabel.textContent = isEnabled ? 'Enabled' : 'Disabled';
+  stateSummary.textContent = isEnabled
+    ? 'Google searches open in the web-only results view.'
+    : 'Google searches open with your browser default behavior.';
+  toggleButton.textContent = isEnabled ? 'Disable' : 'Enable';
+  toggleButton.disabled = false;
+  redirectCount.textContent = formatCount(settings.num_changes);
+};
+
+const renderManifestDetails = () => {
+  const manifest = webext.runtime.getManifest();
+  versionNumber.textContent = manifest.version;
+  releaseNotesLink.href = `https://github.com/prvashisht/classic-web-search/releases/tag/v${manifest.version}`;
+};
+
+const restore = async () => {
+  currentSettings = await getStoredSettings();
+  render(currentSettings);
+};
+
+toggleButton.addEventListener('click', async () => {
+  toggleButton.disabled = true;
+  try {
+    await saveSettings({
+      isWebSearchEnabled: !currentSettings.isWebSearchEnabled,
+    });
+  } catch (error) {
+    console.error('Failed to save options', error);
+    render(currentSettings);
+  }
+});
+
+shortcutsButton.addEventListener('click', async () => {
+  await webext.openShortcutsPage();
+});
+
+webext.storage.onChanged?.addListener((changes, areaName) => {
+  if (areaName !== 'sync' || !changes[SETTINGS_KEY]) {
+    return;
+  }
+
+  currentSettings = {
+    ...DEFAULT_SETTINGS,
+    ...(changes[SETTINGS_KEY].newValue || {}),
+  };
+  render(currentSettings);
+});
+
+renderManifestDetails();
+restore().catch(error => {
+  console.error('Failed to load options', error);
+  statusLabel.textContent = 'Unavailable';
+  stateSummary.textContent = 'Settings could not be loaded.';
+});

--- a/options.js
+++ b/options.js
@@ -1,6 +1,7 @@
 import { webext } from './webext.js';
 
 const SETTINGS_KEY = 'classicWebSearchSettings';
+const SET_CLASSIC_WEB_SEARCH_ENABLED_MESSAGE = 'setClassicWebSearchEnabled';
 const DEFAULT_SETTINGS = {
   isWebSearchEnabled: false,
   num_changes: 0,
@@ -26,13 +27,20 @@ const getStoredSettings = async () => {
   };
 };
 
-const saveSettings = async settings => {
-  const nextSettings = {
-    ...currentSettings,
-    ...settings,
+const setEnabled = async isEnabled => {
+  const response = await webext.runtime.sendMessage({
+    action: SET_CLASSIC_WEB_SEARCH_ENABLED_MESSAGE,
+    isEnabled,
+  });
+
+  if (!response?.ok) {
+    throw new Error('Background update failed');
+  }
+
+  currentSettings = {
+    ...DEFAULT_SETTINGS,
+    ...(response.settings || {}),
   };
-  await webext.storage.sync.set({ [SETTINGS_KEY]: nextSettings });
-  currentSettings = nextSettings;
   render(currentSettings);
 };
 
@@ -64,9 +72,7 @@ const restore = async () => {
 toggleButton.addEventListener('click', async () => {
   toggleButton.disabled = true;
   try {
-    await saveSettings({
-      isWebSearchEnabled: !currentSettings.isWebSearchEnabled,
-    });
+    await setEnabled(!currentSettings.isWebSearchEnabled);
   } catch (error) {
     console.error('Failed to save options', error);
     render(currentSettings);

--- a/service_worker.js
+++ b/service_worker.js
@@ -5,6 +5,7 @@ const CONTEXT_MENU_MANAGE_ID = "manage-extension";
 const CONTEXT_MENU_SHORTCUTS_ID = "manage-keyboard-shortcuts";
 const CONTEXT_MENU_RATE_ID = "rate-classic-web-search";
 const CONTEXT_MENU_SUPPORT_ID = "report-bug-or-support";
+const SET_CLASSIC_WEB_SEARCH_ENABLED_MESSAGE = "setClassicWebSearchEnabled";
 const RATE_REVIEW_URL = "https://vashis.ht/rd/classicwebsearch?from=classicwebsearch-extension-context_menu";
 const SUPPORT_URL = "https://github.com/prvashisht/classic-web-search/issues/new";
 
@@ -186,6 +187,7 @@ let setClassicWebSearchEnabled = async isEnabled => {
   await saveAndApplyExtensionDetails({
     isWebSearchEnabled: isEnabled,
   });
+  return classicWebSearchSettings;
 };
 
 let toggleClassicWebSearch = async () => {
@@ -221,6 +223,23 @@ webext.contextMenus.onClicked.addListener(async info => {
       await webext.tabs.create({ url: SUPPORT_URL });
       break;
   }
+});
+
+webext.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!message || message.action !== SET_CLASSIC_WEB_SEARCH_ENABLED_MESSAGE) {
+    return false;
+  }
+
+  setClassicWebSearchEnabled(Boolean(message.isEnabled))
+    .then(settings => {
+      sendResponse({ ok: true, settings });
+    })
+    .catch(error => {
+      console.error("Failed to update classic web search setting", error);
+      sendResponse({ ok: false });
+    });
+
+  return true;
 });
 
 webext.runtime.onInstalled.addListener(async installInfo => {

--- a/service_worker.js
+++ b/service_worker.js
@@ -126,7 +126,7 @@ let buildContextMenus = async () => {
   });
   createContextMenu({
     id: CONTEXT_MENU_MANAGE_ID,
-    title: "Manage extension",
+    title: "Open options",
     contexts: ["action"],
   });
   createContextMenu({
@@ -209,7 +209,7 @@ webext.contextMenus.onClicked.addListener(async info => {
       );
       break;
     case CONTEXT_MENU_MANAGE_ID:
-      await webext.openExtensionPage();
+      await webext.openOptionsPage();
       break;
     case CONTEXT_MENU_SHORTCUTS_ID:
       await webext.openShortcutsPage();
@@ -254,6 +254,17 @@ webext.runtime.onInstalled.addListener(async installInfo => {
     num_changes: data.classicWebSearchSettings.num_changes || 0,
   });
   await scheduleBuildContextMenus();
+});
+
+webext.storage.onChanged?.addListener((changes, areaName) => {
+  if (areaName !== 'sync' || !changes.classicWebSearchSettings) {
+    return;
+  }
+
+  applyExtensionDetails({
+    ...classicWebSearchSettings,
+    ...(changes.classicWebSearchSettings.newValue || {}),
+  });
 });
 
 webext.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {

--- a/webext.js
+++ b/webext.js
@@ -14,6 +14,16 @@ export const webext = {
   runtime: extensionApi.runtime,
   storage: extensionApi.storage,
   tabs: extensionApi.tabs,
+  openOptionsPage: async () => {
+    if (extensionApi.runtime.openOptionsPage) {
+      await extensionApi.runtime.openOptionsPage();
+      return;
+    }
+
+    await extensionApi.tabs.create({
+      url: extensionApi.runtime.getURL('options.html'),
+    });
+  },
   openExtensionPage: async () => {
     if (isFirefoxRuntime) {
       await extensionApi.tabs.create({ url: 'about:addons' });


### PR DESCRIPTION
## Summary
- Add an extension options page with current state, redirect count, version, release notes, shortcut management, and support links.
- Wire the context menu to open options and route options-page toggles through the service worker so stored redirect counts and other settings are preserved.
- Include the options page files in Chrome and Firefox package builds.
- Bump the extension version from `1.5.0` to `1.6.0`.
- Replace the per-version store deploy skip list with `.github/release-controls.conf`, supporting `skip_release` and `skip_deploy`; `skip_release=true` also prevents store deployment.
- Update README and roadmap docs, including marking the redirect-count hardening follow-up as skipped for now.

## Test plan
- `./build.sh`
- `node --check options.js`
- `node --check service_worker.js`
- `node --check webext.js`
- `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'))"`
- `bash -n .github/scripts/read-release-controls.sh`
- release-control parser checks for default config, `skip_release=true`, and `skip_deploy=true`
- workflow YAML parse via Ruby
- `git diff --check`
- Inspected generated Chrome and Firefox zip contents.